### PR TITLE
Package and upload sdist

### DIFF
--- a/.gitlab-ci.yaml
+++ b/.gitlab-ci.yaml
@@ -48,6 +48,7 @@ package:
     - tools/set_version
     - pip install --upgrade wheel
   script:
+    - python setup.py sdist
     - python setup.py bdist_wheel
   artifacts:
     paths:


### PR DESCRIPTION
According to the official python packaging guidelines: https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives

> You should always upload a source archive and provide built archives for the platforms your project is compatible with.

I have a workflow in which we prefer source builds over binary builds, so it would be nice to have the sdist available on pypi too.